### PR TITLE
fix cmd paths

### DIFF
--- a/src/replicator.js
+++ b/src/replicator.js
@@ -241,9 +241,9 @@ export class Replicator {
 
       await this.cmd(solanaInstallInit, [
         '--config',
-        this.solanaInstallConfig,
+        `"${this.solanaInstallConfig}"`,
         '--data-dir',
-        this.solanaInstallDataDir,
+        `"${this.solanaInstallDataDir}"`,
         '--no-modify-path',
         '--url',
         url,


### PR DESCRIPTION
cmdline app options paths values have to be quoted in order to accept paths with spaces